### PR TITLE
Feedback/call center

### DIFF
--- a/packages/twenty-front/src/modules/chat/call-center/components/PaneSideHeader.tsx
+++ b/packages/twenty-front/src/modules/chat/call-center/components/PaneSideHeader.tsx
@@ -118,7 +118,8 @@ export const PaneSideHeader = () => {
   ) => {
     const sendTemplateInput = {
       integrationId: integrationId,
-      to: `+${phoneNumber}`,
+      to: `${phoneNumber}`,
+      from: `${currentWorkspaceMember?.name.firstName} ${currentWorkspaceMember?.name.lastName}`,
       templateName,
       language,
       message,

--- a/packages/twenty-front/src/modules/chat/call-center/types/SendTemplateInput.ts
+++ b/packages/twenty-front/src/modules/chat/call-center/types/SendTemplateInput.ts
@@ -1,6 +1,7 @@
 export interface SendTemplateInput {
   integrationId: string | null;
   to: string | null;
+  from: string | null;
   templateName: string;
   language: string;
   message: string;

--- a/packages/twenty-server/src/engine/core-modules/meta/whatsapp/dtos/send-message.input.ts
+++ b/packages/twenty-server/src/engine/core-modules/meta/whatsapp/dtos/send-message.input.ts
@@ -87,6 +87,10 @@ export class SendTemplateInput {
 
   @Field()
   @IsString()
+  from: string;
+
+  @Field()
+  @IsString()
   templateName: string;
 
   @Field()

--- a/packages/twenty-server/src/engine/core-modules/meta/whatsapp/types/WhatsappDocument.ts
+++ b/packages/twenty-server/src/engine/core-modules/meta/whatsapp/types/WhatsappDocument.ts
@@ -2,6 +2,7 @@ import { statusEnum } from 'src/engine/core-modules/meta/types/statusEnum';
 
 export type WhatsappDocument = {
   integrationId: string;
+  workspaceId?: string;
   agent?: string;
   sector?: string;
   client: IClient;

--- a/packages/twenty-server/src/engine/core-modules/meta/whatsapp/whatsapp.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/meta/whatsapp/whatsapp.controller.ts
@@ -54,6 +54,8 @@ export class WhatsappController {
   async handleIncomingMessage(
     @Param('workspaceId') workspaceId: string,
     @Param('id') id: string,
+    // TO DO
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     @Body() body: any,
   ) {
     this.logger.log(`${id} - Received incoming message`);
@@ -108,6 +110,7 @@ export class WhatsappController {
         'timeline' | 'unreadMessages' | 'isVisible'
       > = {
         integrationId: id,
+        workspaceId: workspaceId,
         client: {
           phone: body.entry[0].changes[0].value.messages[0].from,
           name: body.entry[0].changes[0].value.contacts[0].profile.name,

--- a/packages/twenty-server/src/engine/core-modules/meta/whatsapp/whatsapp.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/meta/whatsapp/whatsapp.resolver.ts
@@ -19,9 +19,12 @@ export class WhatsappResolver {
   @Mutation(() => Boolean)
   async sendTemplate(
     @Args('sendTemplateInput') sendTemplateInput: SendTemplateInput,
+    @AuthWorkspace() workspace: Workspace,
   ) {
-    const sendTemplateConfirmation =
-      await this.whatsappService.sendTemplate(sendTemplateInput);
+    const sendTemplateConfirmation = await this.whatsappService.sendTemplate(
+      sendTemplateInput,
+      workspace.id,
+    );
 
     if (sendTemplateConfirmation) {
       const today = new Date();

--- a/packages/twenty-server/src/engine/core-modules/meta/whatsapp/whatsapp.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/meta/whatsapp/whatsapp.service.ts
@@ -54,15 +54,28 @@ export class WhatsappService {
     this.firestoreDb = this.firebaseService.getFirestoreDb();
   }
 
-  async sendTemplate(sendTemplateInput: SendTemplateInput) {
+  async sendTemplate(
+    sendTemplateInput: SendTemplateInput,
+    workspaceId: string,
+  ) {
     const { integrationId, to, templateName, language } = sendTemplateInput;
 
-    const integration = await this.whatsappIntegrationRepository.findOne({
+    const whatsappRepository =
+      await this.twentyORMGlobalManager.getRepositoryForWorkspace<WhatsappWorkspaceEntity>(
+        workspaceId,
+        'whatsapp',
+      );
+
+    if (!whatsappRepository) {
+      throw new Error('Whatsapp repository not found');
+    }
+
+    const integration = await whatsappRepository.findOne({
       where: { id: integrationId },
     });
 
     if (!integration) {
-      throw new InternalServerError('Whatsapp integration not found');
+      throw new Error('Whatsapp integration not found');
     }
 
     const fields: any = {


### PR DESCRIPTION
- Adjustment in sending chatbot messages by template: 
Modifies the restart flow of chats generated by templates, so that when the chat is restarted from a template, it does not create a new conversation or contact.

- Directing abandoned chats in the Call Center: 
Adds logic to automatically direct chats to the “abandoned” queue when the SLA (Service Level Agreement) time limit is reached.