### PR TITLE
feat: Add onboarding hook and update WebSoftphone visibility

### DIFF
--- a/packages/twenty-front/src/modules/navigation/hooks/useIsOnboarding.ts
+++ b/packages/twenty-front/src/modules/navigation/hooks/useIsOnboarding.ts
@@ -1,0 +1,10 @@
+import { useLocation } from 'react-router-dom';
+
+export const useIsOnboarding = () => {
+  const location = useLocation();
+  return (
+    /^\/welcome(\/)?$/.test(location.pathname) ||
+    /^\/create\/workspace(\/)?$/.test(location.pathname) ||
+    /^\/create\/profile(\/)?$/.test(location.pathname)
+  );
+};

--- a/packages/twenty-front/src/modules/settings/service-center/telephony/hooks/useGetUserSoftfone.ts
+++ b/packages/twenty-front/src/modules/settings/service-center/telephony/hooks/useGetUserSoftfone.ts
@@ -17,7 +17,7 @@ type UseGetUserSoftfoneReturn = {
 export const useGetUserSoftfone = ({
   extNum,
 }: {
-  extNum: string;
+  extNum?: string;
 }): UseGetUserSoftfoneReturn => {
   const { enqueueSnackBar } = useSnackBar();
 

--- a/packages/twenty-front/src/modules/softphone/components/WebSoftphone.tsx
+++ b/packages/twenty-front/src/modules/softphone/components/WebSoftphone.tsx
@@ -193,7 +193,7 @@ const WebSoftphone: React.FC = () => {
 
   // const { telephonyExtensions, loading } = useFindAllPABX();
   const { telephonyExtension } = useGetUserSoftfone({
-    extNum: workspaceMember?.extensionNumber || '',
+    extNum: workspaceMember?.extensionNumber ?? undefined,
   });
 
   useEffect(() => {
@@ -211,14 +211,19 @@ const WebSoftphone: React.FC = () => {
   }, [telephonyExtension]);
 
   useEffect(() => {
-    if (config?.username && config?.password && config?.domain) {
+    if (
+      config?.username &&
+      config?.password &&
+      config?.domain &&
+      telephonyExtension
+    ) {
       updateConfigWithHa1();
     }
     return () => {
       onComponentUnmount();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [config?.username, config?.password, config?.domain]);
+  }, [config?.username, config?.password, config?.domain, telephonyExtension]);
 
   const startTimer = (
     startTime: number | null,
@@ -831,6 +836,10 @@ const WebSoftphone: React.FC = () => {
       sendDTMF(keyTrimmedLastChar);
     }
   };
+
+  if (!telephonyExtension) {
+    return <></>;
+  }
 
   return (
     <Draggable

--- a/packages/twenty-front/src/modules/ui/layout/page/components/DefaultLayout.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/page/components/DefaultLayout.tsx
@@ -6,10 +6,12 @@ import { AppPageErrorFallback } from '@/error-handler/components/AppPageErrorFal
 import { KeyboardShortcutMenu } from '@/keyboard-shortcut-menu/components/KeyboardShortcutMenu';
 import { AppNavigationDrawer } from '@/navigation/components/AppNavigationDrawer';
 import { MobileNavigationBar } from '@/navigation/components/MobileNavigationBar';
+import { useIsOnboarding } from '@/navigation/hooks/useIsOnboarding';
 import { useIsSettingsPage } from '@/navigation/hooks/useIsSettingsPage';
 import { OBJECT_SETTINGS_WIDTH } from '@/settings/data-model/constants/ObjectSettings';
 import { SignInAppNavigationDrawerMock } from '@/sign-in-background-mock/components/SignInAppNavigationDrawerMock';
 import { SignInBackgroundMockPage } from '@/sign-in-background-mock/components/SignInBackgroundMockPage';
+import WebSoftphone from '@/softphone/components/WebSoftphone';
 import { useShowFullscreen } from '@/ui/layout/fullscreen/hooks/useShowFullscreen';
 import { useShowAuthModal } from '@/ui/layout/hooks/useShowAuthModal';
 import { NAV_DRAWER_WIDTHS } from '@/ui/navigation/navigation-drawer/constants/NavDrawerWidths';
@@ -19,7 +21,6 @@ import styled from '@emotion/styled';
 import { AnimatePresence, LayoutGroup, motion } from 'framer-motion';
 import { Outlet } from 'react-router-dom';
 import { useScreenSize } from 'twenty-ui/utilities';
-import WebSoftphone from '../../../../softphone/components/WebSoftphone';
 
 const StyledLayout = styled.div`
   background: ${({ theme }) => theme.background.noisy};
@@ -71,6 +72,7 @@ export const DefaultLayout = () => {
   const windowsWidth = useScreenSize().width;
   const showAuthModal = useShowAuthModal();
   const useShowFullScreen = useShowFullscreen();
+  const isOnboarding = useIsOnboarding();
 
   return (
     <>
@@ -133,9 +135,11 @@ export const DefaultLayout = () => {
           {isMobile && !showAuthModal && <MobileNavigationBar />}
         </AppErrorBoundary>
       </StyledLayout>
-      <StyledWebSoftphoneContainer>
-        <WebSoftphone />
-      </StyledWebSoftphoneContainer>
+      {!isOnboarding && (
+        <StyledWebSoftphoneContainer>
+          <WebSoftphone />
+        </StyledWebSoftphoneContainer>
+      )}
     </>
   );
 };

--- a/packages/twenty-server/src/engine/core-modules/telephony/telephony.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/telephony/telephony.resolver.ts
@@ -180,8 +180,6 @@ export class TelephonyResolver {
       createTelephonyInput.workspaceId,
     );
 
-    console.log('ramalBody', ramalBody);
-
     try {
       const createdRamal = await this.pabxService.createExtention(ramalBody);
 
@@ -293,13 +291,17 @@ export class TelephonyResolver {
 
   @Query(() => TelephonyExtension, { nullable: true })
   async getUserSoftfone(
-    @Args('extNum', { type: () => String }) extNum: string,
     @Args('workspaceId', { type: () => ID }) workspaceId: string,
-  ): Promise<TelephonyExtension> {
+    @Args('extNum', { type: () => String, nullable: true }) extNum?: string,
+  ): Promise<TelephonyExtension | null> {
     const workspace = await this.workspaceService.findById(workspaceId);
 
     if (!workspace) {
       throw new Error('Workspace not found');
+    }
+
+    if (!extNum) {
+      return null;
     }
 
     const extensions = await this.pabxService.listExtentions({


### PR DESCRIPTION
- Introduced `useIsOnboarding` hook to determine if the user is in the onboarding process.
- Updated `WebSoftphone` component rendering logic in `DefaultLayout` to conditionally display based on onboarding status.
- Modified `useGetUserSoftfone` to accept an optional `extNum` parameter.
- Adjusted `telephony.resolver` to handle nullable `extNum` in the `getUserSoftfone` query.